### PR TITLE
Automatically remove most temporary Docker containers

### DIFF
--- a/xaas/actions/cpu_tuning.py
+++ b/xaas/actions/cpu_tuning.py
@@ -226,7 +226,7 @@ class CPUTuning(Action):
 
         finally:
             for container in containers.values():
-                container.container.stop(timeout=0)
+                container.container.remove(force=True)
 
         config_path = os.path.join(config.build.working_directory, "cpu_tuning.yml")
         config.save(config_path)

--- a/xaas/actions/ir.py
+++ b/xaas/actions/ir.py
@@ -298,7 +298,7 @@ class IRCompiler(Action):
                     errors += 1
 
         for container in containers.values():
-            container.stop(timeout=0)
+            container.remove(force=True)
 
         config_path = os.path.join(config.build.working_directory, "ir_compilation.yml")
         config.save(config_path)


### PR DESCRIPTION
Rather than just stopping the containers, we should actually remove them.

Using `force = True` has the same effect as stopping the container and removing it in one step.